### PR TITLE
fix(codebuild): add validation for Source when the badge property is …

### DIFF
--- a/packages/@aws-cdk/aws-codebuild/lib/project.ts
+++ b/packages/@aws-cdk/aws-codebuild/lib/project.ts
@@ -644,8 +644,11 @@ export class Project extends ProjectBase {
     }
 
     // Render the source and add in the buildspec
-
     const renderSource = () => {
+      if (props.badge && !this.source.badgeSupported) {
+        throw new Error(`Badge is not supported for source type ${this.source.type}`);
+      }
+
       const sourceJson = this.source.toSourceJSON();
       if (typeof buildSpec === 'string') {
         return {

--- a/packages/@aws-cdk/aws-codebuild/lib/source.ts
+++ b/packages/@aws-cdk/aws-codebuild/lib/source.ts
@@ -22,6 +22,7 @@ export interface BuildSourceProps {
 export abstract class BuildSource {
   public readonly identifier?: string;
   public abstract readonly type: SourceType;
+  public readonly badgeSupported: boolean = false;
 
   constructor(props: BuildSourceProps) {
     this.identifier = props.identifier;
@@ -89,6 +90,7 @@ export interface GitBuildSourceProps extends BuildSourceProps {
  * A common superclass of all build sources that are backed by Git.
  */
 export abstract class GitBuildSource extends BuildSource {
+  public readonly badgeSupported: boolean = true;
   private readonly cloneDepth?: number;
 
   protected constructor(props: GitBuildSourceProps) {
@@ -117,6 +119,7 @@ export interface CodeCommitSourceProps extends GitBuildSourceProps {
  */
 export class CodeCommitSource extends GitBuildSource {
   public readonly type: SourceType = SourceType.CodeCommit;
+  public readonly badgeSupported: boolean = false;
   private readonly repo: codecommit.IRepository;
 
   constructor(props: CodeCommitSourceProps) {


### PR DESCRIPTION
…true (#2242)

Badge should not be allowed to be true if Source is not of type GitHub, GitHub Enterprise or Bitbucket.

Fixes #1749


----

### Pull Request Checklist

* [ ] Testing
  - Unit test added (prefer not to modify an existing test, otherwise, it's probably a breaking change)
  - __CLI change?:__ coordinate update of integration tests with team
  - __cdk-init template change?:__ coordinated update of integration tests with team
* [ ] Docs
  - __jsdocs__: All public APIs documented
  - __README__: README and/or documentation topic updated
* [ ] Title and Description
  - __Change type__: title prefixed with **fix**, **feat** will appear in changelog
  - __Title__: use lower-case and doesn't end with a period
  - __Breaking?__: last paragraph: "BREAKING CHANGE: <describe what changed + link for details>"
  - __Issues__: Indicate issues fixed via: "**Fixes #xxx**" or "**Closes #xxx**"
* [ ] Sensitive Modules (requires 2 PR approvers)
  - IAM Policy Document (in @aws-cdk/aws-iam)
  - EC2 Security Groups and ACLs (in @aws-cdk/aws-ec2)
  - Grant APIs (only if not based on official documentation with a reference)

----

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license.
